### PR TITLE
Fix: csf -> json / xml got KeyError

### DIFF
--- a/csf.py
+++ b/csf.py
@@ -129,7 +129,11 @@ class CsfDocument(MutableMapping):
         return (self.__data[lbl] if len(self.__data[lbl]) > 1
                 else self.__data[lbl][0])
 
-    def __setitem__(self, lbl: str, val: Union[CsfVal, List[CsfVal]]):
+    def __setitem__(self,
+                    lbl: str,
+                    val: Union[CsfVal, List[CsfVal], str]):
+        if isinstance(val, str):
+            val = {'value': val, 'extra': None}
         # for multiple value, game would only use the first one.
         try:
             self.__data[lbl][0] = CsfVal(val)

--- a/csf.py
+++ b/csf.py
@@ -282,7 +282,7 @@ def csfToJSONV2(self: CsfDocument, jsonfilepath, encoding='utf-8', indent=2):
             ret = val.copy()
             if '\n' in ret['value']:
                 ret['value'] = ret['value'].split('\n')
-            if not ret['extra']:
+            if 'extra' in ret and not ret['extra']:
                 del ret['extra']
         return ret
 
@@ -333,7 +333,7 @@ def csfToXMLV1(self: CsfDocument, xmlfilepath, indent='\t'):
     """Convert to Shimakaze Csf-XML V1 Document.
     Only `utf-8` supported."""
     def parseCsfVal(elem_node: et.Element, v: CsfVal):
-        if v['extra']:  # not None, not empty
+        if v.get('extra'):  # not None, not empty
             elem_node.attrib['extra'] = v['extra']
         elem_node.text = v['value']
 

--- a/docs/csf.md
+++ b/docs/csf.md
@@ -47,8 +47,8 @@ class CsfDocument(MutableMapping):
     def __getitem__(self, label: str) -> CsfVal | List[CsfVal]:
         """多值标签返回整个列表；
         单值标签只返回第一个（相当于帮你省去 [0] 下标访问）"""
-    def __setitem__(self, label: str, val: CsfVal | List[CsfVal]):
-        """传入列表：直接覆盖。传入单个 CsfVal：覆盖 [0] 号位。
+    def __setitem__(self, label: str, val: CsfVal | List[CsfVal] | str):
+        """传入列表：直接覆盖。传入单个 CsfVal：覆盖 [0] 号位。传入字符串：构建 CsfVal 并赋值。
         注意：游戏只会读第一个值。红警风暴语言编辑器也只能读出两个值。"""
     def __delitem__(self, label: str):
     def __iter__(self):


### PR DESCRIPTION
Users may send partial CsfVal when at runtime, but the output APIs still assumed the *CsfVal*s are full records.